### PR TITLE
fix: handle ranges that span midnight in time calculationsAdjust time range calculations correctly handle intervals

### DIFF
--- a/src/lib/components/time-selector.svelte
+++ b/src/lib/components/time-selector.svelte
@@ -91,7 +91,11 @@
 
                 // Calculate start and end cell indices
                 const startMinutes = startTime.getHours() * 60 + startTime.getMinutes();
-                const endMinutes = endTime.getHours() * 60 + endTime.getMinutes();
+                let endMinutes = endTime.getHours() * 60 + endTime.getMinutes();
+
+                if (endTime.getTime() > startTime.getTime() && endMinutes <= startMinutes) {
+                    endMinutes += 24 * 60;
+                }
 
                 const startY = Math.floor(startMinutes / intervalInMinutes);
                 const endY = Math.floor(endMinutes / intervalInMinutes);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -203,7 +203,11 @@ export function timeSelectionsToCells(
 
         // Calculate start and end cell indices
         const startMinutes = startTime.getHours() * 60 + startTime.getMinutes();
-        const endMinutes = endTime.getHours() * 60 + endTime.getMinutes();
+        let endMinutes = endTime.getHours() * 60 + endTime.getMinutes();
+
+        if (endTime.getTime() > startTime.getTime() && endMinutes <= startMinutes) {
+            endMinutes += 24 * 60;
+        }
 
         const startY = Math.floor(startMinutes / intervalInMinutes);
         const endY = Math.floor(endMinutes / intervalInMinutes);


### PR DESCRIPTION
span midnight by normalizing end minutes when the end time occurs
after the start time but has a smaller minute-of-day value.

- Change const endMinutes to let and add 24*60 minutes when
  endTime > startTime and endMinutes <= startMinutes.
- Apply the same fix in time-selector.svelte and utils.ts to
  ensure consistent behavior across UI and utility code.

This prevents incorrect start/end cell indices for ranges that
cross midnight.